### PR TITLE
Git and Helper Usability

### DIFF
--- a/home/.aliases/ghqaliases
+++ b/home/.aliases/ghqaliases
@@ -1,8 +1,8 @@
-function ghq_and_update() {
+function HELPER_ghq_and_update_ghqfile() {
     \ghq $@ 
     {\ghq list ; cat $DOT_DIR/home/.ghqrepos } | sort | uniq -u > $DOT_DIR/home/.ghqrepos
 }
-alias ghq=ghq_and_update
+alias ghq=HELPER_ghq_and_update_ghqfile
 alias ghqr="cd $(\ghq root)"
 alias github="cd $(\ghq root)/github.com"
 alias code="cd $(\ghq root)/github.com/$(id -un)"

--- a/home/.aliases/gitaliases
+++ b/home/.aliases/gitaliases
@@ -1,5 +1,8 @@
 alias master="git checkout master && git pull"
 alias develop="git checkout develop && git pull"
+alias branches="git for-each-ref --sort=committerdate refs/heads/ --format='%(HEAD) %(color:yellow)%(refname:short)%(color:reset) - %(color:red)%(objectname:short)%(color:reset) - %(contents:subject) - %(authorname) (%(color:green)%(committerdate:relative)%(color:reset))'"
+alias cleanBranches="git fetch --all -p; git branch -vv | grep ": gone]" | awk '{ print $1 }' | xargs -n 1 git branch -D"
+
 
 function HELPER_git_commit_w_changelog() {
     git commit -m "$1: ${@:2}"

--- a/home/.aliases/gitaliases
+++ b/home/.aliases/gitaliases
@@ -14,6 +14,9 @@ alias testCommit="HELPER_git_commit_w_changelog test"
 alias buildCommit="HELPER_git_commit_w_changelog build"
 alias refactorCommit="HELPER_git_commit_w_changelog refactor"
 alias revertCommit="HELPER_git_commit_w_changelog revert"
+alias ciCommit="HELPER_git_commit_w_changelog ci"
+alias choreCommit="HELPER_git_commit_w_changelog chore"
+alias testCommit="HELPER_git_commit_w_changelog test"
 
 function HELPER_setup_github_apps() {
   if [[ ! -d "./.git" ]] ; then 

--- a/home/.aliases/gitaliases
+++ b/home/.aliases/gitaliases
@@ -1,22 +1,21 @@
 alias master="git checkout master && git pull"
 alias develop="git checkout develop && git pull"
 
-function gCommitWChangelog() {
+function HELPER_git_commit_w_changelog() {
     git commit -m "$1: ${@:2}"
 }
 
-alias featCommit="gCommitWChangelog feat"
-alias fixCommit="gCommitWChangelog fix"
-alias breakCommit="gCommitWChangelog 'BREAKING CHANGE'"
-alias docsCommit="gCommitWChangelog docs"
-alias styleCommit="gCommitWChangelog style"
-alias perfCommit="gCommitWChangelog perf"
-alias testCommit="gCommitWChangelog test"
-alias buildCommit="gCommitWChangelog build"
-alias refactorCommit="gCommitWChangelog refactor"
-alias revertCommit="gCommitWChangelog revert"
+alias featCommit="HELPER_git_commit_w_changelog feat"
+alias fixCommit="HELPER_git_commit_w_changelog fix"
+alias docsCommit="HELPER_git_commit_w_changelog docs"
+alias styleCommit="HELPER_git_commit_w_changelog style"
+alias perfCommit="HELPER_git_commit_w_changelog perf"
+alias testCommit="HELPER_git_commit_w_changelog test"
+alias buildCommit="HELPER_git_commit_w_changelog build"
+alias refactorCommit="HELPER_git_commit_w_changelog refactor"
+alias revertCommit="HELPER_git_commit_w_changelog revert"
 
-function setup_github_apps() {
+function HELPER_setup_github_apps() {
   if [[ ! -d "./.git" ]] ; then 
     echo "ERROR: Can only setup github apps for a project with git in root."
     echo "Please move to git project root"
@@ -43,5 +42,3 @@ function setup_github_apps() {
 
   echo "Github apps configured"
 }
-
-alias ghAppsInit="setup_github_apps"

--- a/home/.aliases/texaliases
+++ b/home/.aliases/texaliases
@@ -1,1 +1,1 @@
-alias touchtex="cp ~/.tex_templates/latex-doc.tex.template"
+alias HELPER_new_tex_file="cp ~/.tex_templates/latex-doc.tex.template"

--- a/home/.zaliases
+++ b/home/.zaliases
@@ -45,7 +45,7 @@ alias jsonVerify="python -m json.tool"
 
 
 # Funciton to tagfiles
-function TAGFILE() {
+function HELPER_rename_file_with_tags() {
     fileName="$argv[$#]"
     tags="'${@[1, -2]}"
     tagsCollection=`echo $tags | sed -e "s/ /, /g" | tr -d \'`


### PR DESCRIPTION
- Prefix all helpers with HELPER_ and changed to snake case to make things consistent (aliases use camel case)
- Change the commit shortcuts to match conventional commit convention
- Added short cuts to nicely list local branches and clean local branches not available on remote
